### PR TITLE
drop require ehr-configs

### DIFF
--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -19,9 +19,6 @@
 
 	<require_version>${openMRSVersion}</require_version>
 
-	<require_modules>
-		<require_module version="${ehrconfigsVersion}">org.openmrs.module.ehrconfigs</require_module>
-	</require_modules>
 
 	<extension>
 		<point>org.openmrs.admin.list</point>


### PR DESCRIPTION
```
Ehr-configs required hospital-core to start  before it does, at the same time hospital-core required ehrconfigs to load first thus creating a kinda loop during dependency injection and module startup.
Making hospital core not require EHR-configs at config.xml level resolves the issue.
```